### PR TITLE
Fix non-quoted service string in YAML (deprecated)

### DIFF
--- a/src/DependencyInjection/config/console_listener.yml
+++ b/src/DependencyInjection/config/console_listener.yml
@@ -2,7 +2,7 @@ services:
     vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_exception_listener:
         class: VasekPurchart\TracyBlueScreenBundle\BlueScreen\ConsoleBlueScreenExceptionListener
         arguments:
-            - @vasek_purchart.tracy_blue_screen.tracy.logger
+            - '@vasek_purchart.tracy_blue_screen.tracy.logger'
             - %vasek_purchart.tracy_blue_screen.console.log_directory%
             - %vasek_purchart.tracy_blue_screen.console.browser%
         tags:

--- a/src/DependencyInjection/config/controller_listener.yml
+++ b/src/DependencyInjection/config/controller_listener.yml
@@ -2,7 +2,7 @@ services:
     vasek_purchart.tracy_blue_screen.blue_screen.controller_blue_screen_exception_listener:
         class: VasekPurchart\TracyBlueScreenBundle\BlueScreen\ControllerBlueScreenExceptionListener
         arguments:
-            - @vasek_purchart.tracy_blue_screen.tracy.blue_screen
+            - '@vasek_purchart.tracy_blue_screen.tracy.blue_screen'
         tags:
             -
                 name: kernel.event_listener

--- a/src/DependencyInjection/config/services.yml
+++ b/src/DependencyInjection/config/services.yml
@@ -1,12 +1,12 @@
 services:
-    vasek_purchart.tracy_blue_screen.tracy.blue_screen: @vasek_purchart.tracy_blue_screen.tracy.blue_screen.default
+    vasek_purchart.tracy_blue_screen.tracy.blue_screen: '@vasek_purchart.tracy_blue_screen.tracy.blue_screen.default'
 
     vasek_purchart.tracy_blue_screen.tracy.blue_screen.default:
         class: Tracy\BlueScreen
         factory: [Tracy\Debugger, getBlueScreen]
         public: false
 
-    vasek_purchart.tracy_blue_screen.tracy.logger: @vasek_purchart.tracy_blue_screen.tracy.logger.default
+    vasek_purchart.tracy_blue_screen.tracy.logger: '@vasek_purchart.tracy_blue_screen.tracy.logger.default'
 
     vasek_purchart.tracy_blue_screen.tracy.logger.default:
         class: Tracy\Logger


### PR DESCRIPTION
Not quoting a scalar starting with "@" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.
