### PR TITLE
fix non-quoted parameter reference string in YAML (deprecated)

### DIFF
--- a/src/DependencyInjection/config/services.yml
+++ b/src/DependencyInjection/config/services.yml
@@ -5,7 +5,7 @@ services:
         class: Tracy\BlueScreen
         factory: [VasekPurchart\TracyBlueScreenBundle\BlueScreen\BlueScreenFactory, create]
         arguments:
-            - %vasek_purchart.tracy_blue_screen.blue_screen.collapse_paths%
+            - '%vasek_purchart.tracy_blue_screen.blue_screen.collapse_paths%'
         public: false
 
     vasek_purchart.tracy_blue_screen.tracy.logger: '@vasek_purchart.tracy_blue_screen.tracy.logger.default'


### PR DESCRIPTION
related to #3

(this one was added in 73a84e7b361146a9da476ce5c297ce248c8474e0)