### PR TITLE
Resolve deprecation of "console.exception" event (Symfony 4)

### DIFF
--- a/build/cs-ruleset.xml
+++ b/build/cs-ruleset.xml
@@ -4,7 +4,7 @@
 		<exclude name="PEAR.WhiteSpace.ObjectOperatorIndent.Incorrect"/><!-- structuring Symfony configuration tree needs indentation -->
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionComment.WrongStyle">
-		<exclude-pattern>src/BlueScreen/ConsoleBlueScreenExceptionListener.php</exclude-pattern>
+		<exclude-pattern>src/BlueScreen/ConsoleBlueScreenErrorListener.php</exclude-pattern>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
 		<properties>

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
 	],
 	"require": {
 		"php": "~7.1",
-		"symfony/config": "~3.0",
-		"symfony/console": "~3.0",
-		"symfony/dependency-injection": "~3.0",
-		"symfony/http-kernel": "~3.0",
-		"symfony/yaml": "~3.0",
+		"symfony/config": "~3.3|~4.0",
+		"symfony/console": "~3.3|~4.0",
+		"symfony/dependency-injection": "~3.3|~4.0",
+		"symfony/http-kernel": "~3.3|~4.0",
+		"symfony/yaml": "~3.3|~4.0",
 		"tracy/tracy": "~2.4"
 	},
 	"require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ If you need to change the default position of this listener (see order in `app/c
 
 This bundle expects that you are using the default Symfony profiler screen rendered via the [TwigBundle](http://symfony.com/doc/current/reference/configuration/twig.html), which must be registered.
 
-Console integration also works out of the box, if you do not have an `console.exception` listener that would prevent execution of this one. Again, this can be tweaked using the respective `listener_priority` option.
+Console integration also works out of the box, if you do not have an `console.error` listener that would prevent execution of this one. Again, this can be tweaked using the respective `listener_priority` option.
 
 Configure the `browser` option to open the exceptions directly in your browser, configured binary must be executable with [`exec()`](http://php.net/manual/en/function.exec.php).
 

--- a/src/BlueScreen/ConsoleBlueScreenErrorListener.php
+++ b/src/BlueScreen/ConsoleBlueScreenErrorListener.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\TracyBlueScreenBundle\BlueScreen;
 
-use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Tracy\BlueScreen;
 use Tracy\Logger as TracyLogger;
 
-class ConsoleBlueScreenExceptionListener
+class ConsoleBlueScreenErrorListener
 {
 
 	/** @var \Tracy\Logger */
@@ -38,7 +38,7 @@ class ConsoleBlueScreenExceptionListener
 		$this->browser = $browser;
 	}
 
-	public function onConsoleException(ConsoleExceptionEvent $event): void
+	public function onConsoleError(ConsoleErrorEvent $event): void
 	{
 		if ($this->tracyLogger->directory === null) {
 			$this->tracyLogger->directory = $this->logDirectory;
@@ -53,10 +53,10 @@ class ConsoleBlueScreenExceptionListener
 				'Log directory must be a writable directory, %s [%s] given',
 				$this->tracyLogger->directory,
 				gettype($this->tracyLogger->directory)
-			), 0, $event->getException());
+			), 0, $event->getError());
 		}
 
-		$exception = $event->getException();
+		$exception = $event->getError();
 		$exceptionFile = $this->tracyLogger->getExceptionFile($exception);
 		$this->blueScreen->renderToFile($exception, $exceptionFile);
 

--- a/src/DependencyInjection/config/console_listener.yml
+++ b/src/DependencyInjection/config/console_listener.yml
@@ -1,6 +1,6 @@
 services:
-    vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_exception_listener:
-        class: VasekPurchart\TracyBlueScreenBundle\BlueScreen\ConsoleBlueScreenExceptionListener
+    vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_error_listener:
+        class: VasekPurchart\TracyBlueScreenBundle\BlueScreen\ConsoleBlueScreenErrorListener
         arguments:
             - '@vasek_purchart.tracy_blue_screen.tracy.logger'
             - '@vasek_purchart.tracy_blue_screen.tracy.blue_screen'
@@ -9,5 +9,5 @@ services:
         tags:
             -
                 name: kernel.event_listener
-                event: console.exception
+                event: console.error
                 priority: '%vasek_purchart.tracy_blue_screen.console.listener_priority%'

--- a/tests/BlueScreen/ConsoleBlueScreenExceptionListenerTest.php
+++ b/tests/BlueScreen/ConsoleBlueScreenExceptionListenerTest.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace VasekPurchart\TracyBlueScreenBundle\BlueScreen;
 
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -31,7 +31,7 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 			->with($this->stringContains('saved in file'));
 		$exception = new \Exception('Foobar!');
 
-		$event = new ConsoleExceptionEvent($command, $input, $output, $exception, 1);
+		$event = new ConsoleErrorEvent($input, $output, $exception, $command);
 
 		$logger = $this->createMock(TracyLogger::class);
 		$logger
@@ -46,13 +46,13 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 			->method('renderToFile')
 			->with($exception, $file);
 
-		$listener = new ConsoleBlueScreenExceptionListener(
+		$listener = new ConsoleBlueScreenErrorListener(
 			$logger,
 			$blueScreen,
 			$directory,
 			null
 		);
-		$listener->onConsoleException($event);
+		$listener->onConsoleError($event);
 	}
 
 	public function testUsesErrorOutputIfPossible(): void
@@ -76,7 +76,7 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 
 		$exception = new \Exception('Foobar!');
 
-		$event = new ConsoleExceptionEvent($command, $input, $output, $exception, 1);
+		$event = new ConsoleErrorEvent($input, $output, $exception, $command);
 
 		$logger = $this->createMock(TracyLogger::class);
 		$logger
@@ -91,13 +91,13 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 			->method('renderToFile')
 			->with($exception, $file);
 
-		$listener = new ConsoleBlueScreenExceptionListener(
+		$listener = new ConsoleBlueScreenErrorListener(
 			$logger,
 			$blueScreen,
 			$directory,
 			null
 		);
-		$listener->onConsoleException($event);
+		$listener->onConsoleError($event);
 	}
 
 	public function testMissingLogDir(): void
@@ -107,12 +107,12 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 		$output = $this->createMock(OutputInterface::class);
 		$exception = new \Exception('Foobar!');
 
-		$event = new ConsoleExceptionEvent($command, $input, $output, $exception, 1);
+		$event = new ConsoleErrorEvent($input, $output, $exception, $command);
 
 		$logger = $this->createMock(TracyLogger::class);
 		$blueScreen = $this->createMock(BlueScreen::class);
 
-		$listener = new ConsoleBlueScreenExceptionListener(
+		$listener = new ConsoleBlueScreenErrorListener(
 			$logger,
 			$blueScreen,
 			null,
@@ -121,7 +121,7 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 
 		$this->expectException(\InvalidArgumentException::class);
 
-		$listener->onConsoleException($event);
+		$listener->onConsoleError($event);
 	}
 
 }

--- a/tests/DependencyInjection/TracyBlueScreenExtensionConsoleTest.php
+++ b/tests/DependencyInjection/TracyBlueScreenExtensionConsoleTest.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\TracyBlueScreenBundle\DependencyInjection;
 
-use VasekPurchart\TracyBlueScreenBundle\BlueScreen\ConsoleBlueScreenExceptionListener;
+use VasekPurchart\TracyBlueScreenBundle\BlueScreen\ConsoleBlueScreenErrorListener;
 
 class TracyBlueScreenExtensionConsoleTest extends \Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase
 {
@@ -33,9 +33,9 @@ class TracyBlueScreenExtensionConsoleTest extends \Matthias\SymfonyDependencyInj
 	{
 		$this->load();
 
-		$this->assertContainerBuilderHasService('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_exception_listener', ConsoleBlueScreenExceptionListener::class);
-		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_exception_listener', 'kernel.event_listener', [
-			'event' => 'console.exception',
+		$this->assertContainerBuilderHasService('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_error_listener', ConsoleBlueScreenErrorListener::class);
+		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_error_listener', 'kernel.event_listener', [
+			'event' => 'console.error',
 			'priority' => '%' . TracyBlueScreenExtension::CONTAINER_PARAMETER_CONSOLE_LISTENER_PRIORITY . '%',
 		]);
 
@@ -50,7 +50,7 @@ class TracyBlueScreenExtensionConsoleTest extends \Matthias\SymfonyDependencyInj
 			],
 		]);
 
-		$this->assertContainerBuilderNotHasService('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_exception_listener');
+		$this->assertContainerBuilderNotHasService('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_error_listener');
 
 		$this->compile();
 	}
@@ -63,9 +63,9 @@ class TracyBlueScreenExtensionConsoleTest extends \Matthias\SymfonyDependencyInj
 			],
 		]);
 
-		$this->assertContainerBuilderHasService('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_exception_listener', ConsoleBlueScreenExceptionListener::class);
-		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_exception_listener', 'kernel.event_listener', [
-			'event' => 'console.exception',
+		$this->assertContainerBuilderHasService('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_error_listener', ConsoleBlueScreenErrorListener::class);
+		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.tracy_blue_screen.blue_screen.console_blue_screen_error_listener', 'kernel.event_listener', [
+			'event' => 'console.error',
 			'priority' => '%' . TracyBlueScreenExtension::CONTAINER_PARAMETER_CONSOLE_LISTENER_PRIORITY . '%',
 		]);
 


### PR DESCRIPTION
fixes #9
adds requirement for symfony/console 3.3 - not really BC break because composer will take care of that