### PR TITLE
Refactor tests

### DIFF
--- a/tests/BlueScreen/ConsoleBlueScreenExceptionListenerTest.php
+++ b/tests/BlueScreen/ConsoleBlueScreenExceptionListenerTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\TracyBlueScreenBundle\BlueScreen;
 
+use PHPUnit\Framework\Assert;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,23 +27,23 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 		$input = $this->createMock(InputInterface::class);
 		$output = $this->createMock(OutputInterface::class);
 		$output
-			->expects($this->once())
+			->expects(self::once())
 			->method('writeln')
-			->with($this->stringContains('saved in file'));
+			->with(Assert::stringContains('saved in file'));
 		$exception = new \Exception('Foobar!');
 
 		$event = new ConsoleErrorEvent($input, $output, $exception, $command);
 
 		$logger = $this->createMock(TracyLogger::class);
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('getExceptionFile')
 			->with($exception)
-			->will($this->returnValue($file));
+			->will(self::returnValue($file));
 
 		$blueScreen = $this->createMock(BlueScreen::class);
 		$blueScreen
-			->expects($this->once())
+			->expects(self::once())
 			->method('renderToFile')
 			->with($exception, $file);
 
@@ -65,14 +66,14 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 		$input = $this->createMock(InputInterface::class);
 		$errorOutput = $this->createMock(OutputInterface::class);
 		$errorOutput
-			->expects($this->once())
+			->expects(self::once())
 			->method('writeln')
-			->with($this->stringContains('saved in file'));
+			->with(Assert::stringContains('saved in file'));
 		$output = $this->createMock(ConsoleOutputInterface::class);
 		$output
-			->expects($this->once())
+			->expects(self::once())
 			->method('getErrorOutput')
-			->will($this->returnValue($errorOutput));
+			->will(self::returnValue($errorOutput));
 
 		$exception = new \Exception('Foobar!');
 
@@ -80,14 +81,14 @@ class ConsoleBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestCase
 
 		$logger = $this->createMock(TracyLogger::class);
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('getExceptionFile')
 			->with($exception)
-			->will($this->returnValue($file));
+			->will(self::returnValue($file));
 
 		$blueScreen = $this->createMock(BlueScreen::class);
 		$blueScreen
-			->expects($this->once())
+			->expects(self::once())
 			->method('renderToFile')
 			->with($exception, $file);
 

--- a/tests/BlueScreen/ControllerBlueScreenExceptionListenerTest.php
+++ b/tests/BlueScreen/ControllerBlueScreenExceptionListenerTest.php
@@ -23,7 +23,7 @@ class ControllerBlueScreenExceptionListenerTest extends \PHPUnit\Framework\TestC
 
 		$blueScreen = $this->createMock(BlueScreen::class);
 		$blueScreen
-			->expects($this->once())
+			->expects(self::once())
 			->method('render')
 			->with($exception);
 

--- a/tests/DependencyInjection/TracyBlueScreenExtensionControllerTest.php
+++ b/tests/DependencyInjection/TracyBlueScreenExtensionControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\TracyBlueScreenBundle\DependencyInjection;
 
+use Generator;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 use VasekPurchart\TracyBlueScreenBundle\BlueScreen\ControllerBlueScreenExceptionListener;
 
@@ -38,9 +39,31 @@ class TracyBlueScreenExtensionControllerTest extends \Matthias\SymfonyDependency
 		];
 	}
 
-	public function testEnabledByDefault(): void
+	public function enabledDataProvider(): Generator
 	{
-		$this->loadExtensions();
+		yield 'enabled by default' => [
+			'configuration' => [],
+		];
+
+		yield 'enabled by configuration' => [
+			'configuration' => [
+				'tracy_blue_screen' => [
+					'controller' => [
+						'enabled' => true,
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider enabledDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 */
+	public function testEnabled(array $configuration): void
+	{
+		$this->loadExtensions($configuration);
 
 		$this->assertContainerBuilderHasService('vasek_purchart.tracy_blue_screen.blue_screen.controller_blue_screen_exception_listener', ControllerBlueScreenExceptionListener::class);
 		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.tracy_blue_screen.blue_screen.controller_blue_screen_exception_listener', 'kernel.event_listener', [
@@ -60,23 +83,6 @@ class TracyBlueScreenExtensionControllerTest extends \Matthias\SymfonyDependency
 		]);
 
 		$this->assertContainerBuilderNotHasService('vasek_purchart.tracy_blue_screen.blue_screen.controller_blue_screen_exception_listener');
-	}
-
-	public function testEnabled(): void
-	{
-		$this->loadExtensions([
-			'tracy_blue_screen' => [
-				'controller' => [
-					'enabled' => true,
-				],
-			],
-		]);
-
-		$this->assertContainerBuilderHasService('vasek_purchart.tracy_blue_screen.blue_screen.controller_blue_screen_exception_listener', ControllerBlueScreenExceptionListener::class);
-		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.tracy_blue_screen.blue_screen.controller_blue_screen_exception_listener', 'kernel.event_listener', [
-			'event' => 'kernel.exception',
-			'priority' => '%' . TracyBlueScreenExtension::CONTAINER_PARAMETER_CONTROLLER_LISTENER_PRIORITY . '%',
-		]);
 	}
 
 	public function testConfigureListenerPriority(): void

--- a/tests/DependencyInjection/TracyBlueScreenExtensionTest.php
+++ b/tests/DependencyInjection/TracyBlueScreenExtensionTest.php
@@ -67,8 +67,8 @@ class TracyBlueScreenExtensionTest extends \Matthias\SymfonyDependencyInjectionT
 	{
 		$this->loadExtensions();
 
-		$this->assertContainerBuilderHasParameter('vasek_purchart.tracy_blue_screen.blue_screen.collapse_paths');
-		$collapsePaths = $this->container->getParameter('vasek_purchart.tracy_blue_screen.blue_screen.collapse_paths');
+		$this->assertContainerBuilderHasParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
+		$collapsePaths = $this->container->getParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 
 		$this->assertArrayContainsStringPart('/bootstrap.php.cache', $collapsePaths);
 		$this->assertArrayContainsStringPart('/tests-cache-dir', $collapsePaths);
@@ -88,8 +88,8 @@ class TracyBlueScreenExtensionTest extends \Matthias\SymfonyDependencyInjectionT
 			],
 		]);
 
-		$this->assertContainerBuilderHasParameter('vasek_purchart.tracy_blue_screen.blue_screen.collapse_paths');
-		$collapsePaths = $this->container->getParameter('vasek_purchart.tracy_blue_screen.blue_screen.collapse_paths');
+		$this->assertContainerBuilderHasParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
+		$collapsePaths = $this->container->getParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 
 		$this->assertEquals($paths, $collapsePaths);
 	}
@@ -104,8 +104,8 @@ class TracyBlueScreenExtensionTest extends \Matthias\SymfonyDependencyInjectionT
 			],
 		]);
 
-		$this->assertContainerBuilderHasParameter('vasek_purchart.tracy_blue_screen.blue_screen.collapse_paths');
-		$collapsePaths = $this->container->getParameter('vasek_purchart.tracy_blue_screen.blue_screen.collapse_paths');
+		$this->assertContainerBuilderHasParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
+		$collapsePaths = $this->container->getParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 
 		$this->assertEmpty($collapsePaths);
 	}

--- a/tests/DependencyInjection/TracyBlueScreenExtensionTest.php
+++ b/tests/DependencyInjection/TracyBlueScreenExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\TracyBlueScreenBundle\DependencyInjection;
 
+use PHPUnit\Framework\Assert;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -91,7 +92,7 @@ class TracyBlueScreenExtensionTest extends \Matthias\SymfonyDependencyInjectionT
 		$this->assertContainerBuilderHasParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 		$collapsePaths = $this->container->getParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 
-		$this->assertEquals($paths, $collapsePaths);
+		Assert::assertEquals($paths, $collapsePaths);
 	}
 
 	public function testEmptyCollapseDirs(): void
@@ -107,7 +108,7 @@ class TracyBlueScreenExtensionTest extends \Matthias\SymfonyDependencyInjectionT
 		$this->assertContainerBuilderHasParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 		$collapsePaths = $this->container->getParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 
-		$this->assertEmpty($collapsePaths);
+		Assert::assertEmpty($collapsePaths);
 	}
 
 	/**
@@ -164,7 +165,7 @@ class TracyBlueScreenExtensionTest extends \Matthias\SymfonyDependencyInjectionT
 				break;
 			}
 		}
-		$this->assertTrue($found, sprintf('%s not found in any elements of the given %s', $string, var_export($array, true)));
+		Assert::assertTrue($found, sprintf('%s not found in any elements of the given %s', $string, var_export($array, true)));
 	}
 
 }

--- a/tests/DependencyInjection/TracyBlueScreenExtensionTest.php
+++ b/tests/DependencyInjection/TracyBlueScreenExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\TracyBlueScreenBundle\DependencyInjection;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -64,51 +65,70 @@ class TracyBlueScreenExtensionTest extends \Matthias\SymfonyDependencyInjectionT
 		$this->assertArrayContainsStringPart('/vendor', $collapsePaths);
 	}
 
-	public function testCollapseCacheDirsByDefault(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function collapsePathsConfigurationDataProvider(): Generator
 	{
-		$this->loadExtensions();
-
-		$this->assertContainerBuilderHasParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
-		$collapsePaths = $this->container->getParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
-
-		$this->assertArrayContainsStringPart('/bootstrap.php.cache', $collapsePaths);
-		$this->assertArrayContainsStringPart('/tests-cache-dir', $collapsePaths);
-	}
-
-	public function testSetCollapseDirs(): void
-	{
-		$paths = [
-			__DIR__ . '/foobar',
+		yield 'collapse cache dirs by default' => [
+			'configuration' => [],
+			'expectedCollapsePaths' => [
+				'/bootstrap.php.cache',
+				'/tests-cache-dir',
+			],
 		];
 
-		$this->loadExtensions([
-			'tracy_blue_screen' => [
-				'blue_screen' => [
-					'collapse_paths' => $paths,
+		yield 'set collapse dirs' => (static function (): array {
+			$paths = [
+				__DIR__ . '/foobar',
+			];
+
+			return [
+				'configuration' => [
+					'tracy_blue_screen' => [
+						'blue_screen' => [
+							'collapse_paths' => $paths,
+						],
+					],
 				],
-			],
-		]);
+				'expectedCollapsePaths' => $paths,
+			];
+		})();
 
-		$this->assertContainerBuilderHasParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
-		$collapsePaths = $this->container->getParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
-
-		Assert::assertEquals($paths, $collapsePaths);
+		yield 'empty collapse dirs' => (static function (): array {
+			return [
+				'configuration' => [
+					'tracy_blue_screen' => [
+						'blue_screen' => [
+							'collapse_paths' => [],
+						],
+					],
+				],
+				'expectedCollapsePaths' => [],
+			];
+		})();
 	}
 
-	public function testEmptyCollapseDirs(): void
+	/**
+	 * @dataProvider collapsePathsConfigurationDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 * @param string[] $expectedCollapsePaths
+	 */
+	public function testCollapsePathsConfiguration(
+		array $configuration,
+		array $expectedCollapsePaths
+	): void
 	{
-		$this->loadExtensions([
-			'tracy_blue_screen' => [
-				'blue_screen' => [
-					'collapse_paths' => [],
-				],
-			],
-		]);
+		$this->loadExtensions($configuration);
 
 		$this->assertContainerBuilderHasParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 		$collapsePaths = $this->container->getParameter(TracyBlueScreenExtension::CONTAINER_PARAMETER_BLUE_SCREEN_COLLAPSE_PATHS);
 
-		Assert::assertEmpty($collapsePaths);
+		foreach ($expectedCollapsePaths as $expectedCollapsePath) {
+			$this->assertArrayContainsStringPart($expectedCollapsePath, $collapsePaths);
+		}
+		Assert::assertCount(count($expectedCollapsePaths), $collapsePaths);
 	}
 
 	/**


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks